### PR TITLE
Update jQuery to 2.1.3

### DIFF
--- a/pb/crossdomain.php
+++ b/pb/crossdomain.php
@@ -82,7 +82,7 @@ if (isset($PokemonServers[$config['host']])) {
 header('P3P: CP="NOI CUR ADM DEV COM NAV STA OUR IND"');
 ?>
 <!DOCTYPE html>
-<script src="/js/lib/jquery-2.1.0.min.js"></script>
+<script src="/js/lib/jquery-2.1.3.min.js"></script>
 <script src="/js/lib/jquery-cookie.js"></script>
 <script src="/js/lib/jquery.json-2.3.min.js"></script>
 <body>


### PR DESCRIPTION
Some browser errors come up for newer versions of Firefox
Edits also need to be made to crossprotocol.php, index.template.html, testclient.html, and pokedex.php

js/lib/jquery-2.1.0.min.js Needs to be deleted in favor of a js/lib/jquery-2.1.3.min.js for new changes to come into effect
